### PR TITLE
Fix "Error: 'default' is not exported"

### DIFF
--- a/vue.js
+++ b/vue.js
@@ -6,7 +6,7 @@ Description: Single-File Components of Vue.js Framework
 */
 var module = module ? module : {};
 
-export default function(hljs) {
+export default function hljsDefineVue(hljs) {
   return {
     subLanguage: "xml",
     contains: [

--- a/vue.js
+++ b/vue.js
@@ -6,7 +6,7 @@ Description: Single-File Components of Vue.js Framework
 */
 var module = module ? module : {};
 
-function hljsDefineVue(hljs) {
+export default function hljsDefineVue(hljs) {
   return {
     subLanguage: "xml",
     contains: [

--- a/vue.js
+++ b/vue.js
@@ -6,7 +6,7 @@ Description: Single-File Components of Vue.js Framework
 */
 var module = module ? module : {};
 
-export default function hljsDefineVue(hljs) {
+export default function(hljs) {
   return {
     subLanguage: "xml",
     contains: [


### PR DESCRIPTION
Under esm it's throwing "[!] Error: 'default' is not exported by external/ui_npm/node_modules/highlightjs-vue/dist/highlightjs-vue.esm.js, imported by lib/highlightjs/index.js"